### PR TITLE
ci: add op-node ECR release workflow

### DIFF
--- a/.github/workflows/op-node-ghcr-release.yml
+++ b/.github/workflows/op-node-ghcr-release.yml
@@ -1,0 +1,65 @@
+name: Publish op-node to GHCR
+
+on:
+  push:
+    tags:
+      - "op-node/v*"
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/bnb-chain/op-node
+
+jobs:
+  push-op-node-ghcr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Derive image tags
+        id: vars
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME#op-node/}"
+          if [[ -z "$VERSION" || "$VERSION" == "$GITHUB_REF_NAME" ]]; then
+            echo "failed to derive version from tag: $GITHUB_REF_NAME"
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "tags<<EOF"
+            echo "${IMAGE_NAME}:${VERSION}"
+            if [[ "$VERSION" != *"-rc"* ]]; then
+              echo "${IMAGE_NAME}:latest"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./op-node/Dockerfile
+          platforms: linux/amd64
+          push: true
+          build-args: |
+            VERSION=${{ steps.vars.outputs.version }}
+          tags: ${{ steps.vars.outputs.tags }}

--- a/.github/workflows/op-node-ghcr-release.yml
+++ b/.github/workflows/op-node-ghcr-release.yml
@@ -1,19 +1,16 @@
-name: Publish op-node to GHCR
+name: Publish op-node to ECR
 
 on:
   push:
     tags:
       - "op-node/v*"
 
-permissions:
-  contents: read
-  packages: write
-
 env:
-  IMAGE_NAME: ghcr.io/bnb-chain/op-node
+  ECR_REGISTRY: 305587085711.dkr.ecr.us-west-2.amazonaws.com
+  IMAGE_NAME: 305587085711.dkr.ecr.us-west-2.amazonaws.com/opbnb-node
 
 jobs:
-  push-op-node-ghcr:
+  push-op-node-ecr:
     runs-on: ubuntu-latest
 
     steps:
@@ -46,12 +43,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to GHCR
+      - name: Login to ECR
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ${{ env.ECR_REGISTRY }}
+          username: ${{ secrets.ECR_ACCESS_KEY_ID }}
+          password: ${{ secrets.ECR_ACCESS_KEY }}
 
       - name: Build and push
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions workflow for publishing op-node to GHCR
- trigger on op-node/v* tags without changing the existing docker release workflow
- publish linux/amd64 images as ghcr.io/bnb-chain/op-node:<version> and update latest for non-rc tags

## Testing
- not run (workflow change only)
